### PR TITLE
Fix missing astpretty dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     version=get_version(),
     author='Ilya Lebedev',
     author_email='melevir@gmail.com',
-    install_requires=['setuptools'],
+    install_requires=['astpretty', 'flake8', 'setuptools'],
     entry_points={
         'flake8.extension': [
             'ECE = flake8_expression_complexity.checker:ExpressionComplexityChecker',


### PR DESCRIPTION
Running the following in a clean virtualenv:
```
pip install flake8 flake8-expression-complexity
flake8
```

Results in an error like the following:
```
File ".../lib/python3.6/site-packages/flake8_expression_complexity/utils/complexity.py", line 5, in <module>
  from astpretty import pprint
ModuleNotFoundError: No module named 'astpretty'
```

This change adds `astpretty` and `flake8` as requirements for this
package, fixing this error.