### PR TITLE
Support of pattern matching syntax

### DIFF
--- a/flake8_expression_complexity/utils/complexity.py
+++ b/flake8_expression_complexity/utils/complexity.py
@@ -53,6 +53,14 @@ if sys.version_info >= (3, 8):
         (ast.NamedExpr, 'walrus'),
     )
 
+if sys.version_info >= (3, 10):
+    TYPES_MAP.extend(
+        [
+            (ast.Match, 'match'),
+            (ast.match_case, 'case'),
+        ]
+    )
+
 
 def get_expression_complexity(node: ast.AST) -> float:
     info = get_expression_part_info(node)
@@ -89,6 +97,8 @@ def get_complexity_increase_for_node_type(node_type_sid: str) -> float:
         'simple_type': 0,
         'fstring': 2,
         'walrus': 2,
+        'match': 1,
+        'case': 1,
     }
     return nodes_scores_map[node_type_sid]
 
@@ -136,5 +146,7 @@ def _get_sub_nodes(node: Any, node_type_sid: str) -> List[ast.AST]:
         'attribute': lambda n: [n.value],
         'simple_type': lambda n: [],
         'walrus': lambda n: [n.target, n.value],
+        'match': lambda n: n.cases,
+        'case': lambda n: [],
     }
     return subnodes_map[node_type_sid](node)

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -13,3 +13,9 @@ def test_fails():
 def test_walrus():
     errors = run_validator_for_test_file('walrus.py', max_expression_complexity=1)
     assert len(errors) == 1
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason='runs only for python 3.10+')
+def test_match():
+    errors = run_validator_for_test_file('match.py', max_expression_complexity=1)
+    assert len(errors) == 1

--- a/tests/test_files/match.py
+++ b/tests/test_files/match.py
@@ -1,0 +1,8 @@
+link = '<https://example.com/path/>; rel="next"'
+match link.split('; '):
+    case [brackets_link, 'rel="next"']:
+        url = brackets_link[1:-1]
+    case [brackets_link, 'rel="previous"']:
+        url = brackets_link[1:-1]
+    case 'blank':
+        url = ''


### PR DESCRIPTION
I've added support to pattern matching syntax. Any match-case node will have complexity 2.  This pull request fix this issue: https://github.com/best-doctor/flake8-expression-complexity/issues/19