### PR TITLE
fix: change to use ast.Constant

### DIFF
--- a/flake8_expression_complexity/utils/complexity.py
+++ b/flake8_expression_complexity/utils/complexity.py
@@ -40,9 +40,9 @@ TYPES_MAP = [
     (ast.ClassDef, 'classdef'),
     (
         (
-            ast.Name, ast.Import, ast.Str, ast.Num, ast.NameConstant, ast.Bytes, ast.Nonlocal,
+            ast.Name, ast.Import, ast.Nonlocal,
             ast.ImportFrom, ast.Pass, ast.Raise, ast.Break, ast.Continue, type(None),
-            ast.Ellipsis, ast.Global,
+            ast.Constant, ast.Global,
         ),
         'simple_type',
     ),


### PR DESCRIPTION
aliases of ast.Constant were removed in python 3.14

Fixes #25